### PR TITLE
Use a single thread to communicate to the VME crate

### DIFF
--- a/DataModel/DataModel.h
+++ b/DataModel/DataModel.h
@@ -5,6 +5,11 @@
 #include <string>
 #include <vector>
 
+#include <zmq.hpp>
+
+#include <caen++/v1290.hpp>
+#include <caen++/v792.hpp>
+
 //#include "TTree.h"
 
 #include "Store.h"
@@ -13,11 +18,7 @@
 #include "DAQUtilities.h"
 #include "SlowControlCollection.h"
 #include "DAQDataModelBase.h"
-
-#include <zmq.hpp>
-
-#include <caen++/v1290.hpp>
-#include <caen++/v792.hpp>
+#include "ThreadLoop.h"
 
 using namespace ToolFramework;
 
@@ -43,6 +44,8 @@ class DataModel : public DAQDataModelBase {
   //TTree* GetTTree(std::string name);
   //void AddTTree(std::string name,TTree *tree);
   //void DeleteTTree(std::string name,TTree *tree);
+
+  ThreadLoop vme_readout;
 
   std::mutex v1290_mutex;
   std::list<std::vector<caen::V1290::Packet>> v1290_readout;

--- a/DataModel/ThreadLoop.cpp
+++ b/DataModel/ThreadLoop.cpp
@@ -1,0 +1,121 @@
+#include "ThreadLoop.h"
+
+ThreadLoop::~ThreadLoop() {
+  if (!thread) return;
+  stop_ = true;
+  thread->join();
+  delete thread;
+};
+
+void ThreadLoop::clear() {
+  stop_ = true;
+  if (thread) {
+    thread->join();
+    delete thread;
+  };
+  actions.clear();
+  subscriptions.clear();
+  current = actions.end();
+};
+
+void ThreadLoop::lock() {
+  if (!mutex.try_lock()) {
+    pause_ = true;
+    mutex.lock();
+  };
+};
+
+void ThreadLoop::unlock() {
+  mutex.unlock();
+  if (pause_) {
+    pause_ = false;
+    cv.notify_all();
+  };
+};
+
+ThreadLoop::handle ThreadLoop::subscribe(std::function<bool ()> function) {
+  lock();
+  try {
+    actions.push_front({ std::move(function), nullptr });
+    subscriptions.push_front({ actions.begin(), false });
+    actions.front().subscription = &subscriptions.front();
+
+    unlock();
+  } catch (...) {
+    unlock();
+    throw;
+  };
+
+  if (thread && stop_) {
+    thread->join();
+    delete thread;
+    thread = nullptr;
+  };
+
+  if (!thread) {
+    stop_ = false;
+    thread = new std::thread(&ThreadLoop::loop, this);
+  };
+
+  return subscriptions.begin();
+};
+
+void ThreadLoop::loop() {
+  std::unique_lock<std::mutex> lock(mutex);
+  while (true) {
+    if (pause_) {
+      paused_ = true;
+      cv.notify_all();
+      cv.wait(lock, [this]() -> bool { return !pause_; });
+      paused_ = false;
+    };
+
+    if (stop_) return;
+
+    if (current == actions.end()) {
+      current = actions.begin();
+      if (current == actions.end()) return;
+    };
+
+    lock.unlock();
+    bool keep = current->function();
+    lock.lock();
+    if (keep)
+      ++current;
+    else {
+      current->subscription->erased = true;
+      actions.erase(current++);
+    };
+  };
+};
+
+void ThreadLoop::unsubscribe(ThreadLoop::handle handle) {
+  if (!handle->erased) {
+    lock();
+    try {
+      if (current == handle->iterator && !paused_) {
+        pause_ = true;
+        std::unique_lock<std::mutex> lock(mutex, std::adopt_lock);
+        cv.wait(lock, [this]() -> bool { return paused_; });
+        lock.release();
+      };
+
+      if (current == handle->iterator) ++current;
+
+      actions.erase(handle->iterator);
+
+      unlock();
+    } catch (...) {
+      unlock();
+      throw;
+    };
+  };
+
+  subscriptions.erase(handle);
+
+  if (actions.empty() && thread) {
+    thread->join();
+    delete thread;
+    thread = nullptr;
+  };
+};

--- a/DataModel/ThreadLoop.h
+++ b/DataModel/ThreadLoop.h
@@ -1,0 +1,54 @@
+#ifndef THREAD_LOOP_H
+#define THREAD_LOOP_H
+
+#include <condition_variable>
+#include <functional>
+#include <list>
+#include <mutex>
+#include <thread>
+
+class ThreadLoop {
+  private:
+    struct Action;
+
+    struct Subscription {
+      std::list<Action>::iterator iterator;
+      bool erased;
+    };
+
+    struct Action {
+      std::function<bool ()> function;
+      Subscription* subscription;
+    };
+
+  public:
+    using handle = std::list<Subscription>::iterator;
+
+    ~ThreadLoop();
+
+    handle subscribe(std::function<bool ()>);
+    void unsubscribe(handle);
+
+    void pause()  { pause_ = true;  };
+    void resume() { pause_ = false; };
+    bool paused() const { return pause_;  };
+
+    void clear();
+
+  private:
+    std::list<Action> actions;
+    std::list<Action>::iterator current = actions.end();
+    std::list<Subscription> subscriptions;
+    std::thread* thread = nullptr;
+    std::mutex mutex;
+    std::condition_variable cv;
+    bool pause_  = false;
+    bool paused_ = false;
+    bool stop_   = false;
+
+    void loop();
+    void lock();
+    void unlock();
+};
+
+#endif

--- a/UserTools/V1290/V1290.cpp
+++ b/UserTools/V1290/V1290.cpp
@@ -82,7 +82,6 @@ static bool cfg_get_mask(
       else      mask &= ~bit;
     };
   };
-  fprintf(stderr, "cfg_get_mask %s => %x, %d\n", name.c_str(), mask, set);
   return set;
 };
 

--- a/UserTools/V1290/V1290.h
+++ b/UserTools/V1290/V1290.h
@@ -10,8 +10,6 @@
 
 class V1290: public ToolFramework::Tool {
   public:
-    ~V1290();
-
     bool Initialise(std::string configfile, DataModel&);
     bool Execute();
     bool Finalise();
@@ -19,7 +17,7 @@ class V1290: public ToolFramework::Tool {
   private:
     std::vector<caen::V1290> tdcs;
     caen::V1290::Buffer buffer;
-    std::unique_ptr<ThreadLoop::handle> thread;
+    ThreadLoop::Thread thread;
 
     void connect();
     void configure();

--- a/UserTools/V1290/V1290.h
+++ b/UserTools/V1290/V1290.h
@@ -6,33 +6,24 @@
 #include <caen++/v1290.hpp>
 
 #include "Tool.h"
-#include "Utilities.h"
+#include "ThreadLoop.h"
 
 class V1290: public ToolFramework::Tool {
   public:
+    ~V1290();
+
     bool Initialise(std::string configfile, DataModel&);
     bool Execute();
     bool Finalise();
 
   private:
-    struct Thread: public ToolFramework::Thread_args {
-      V1290& tool;
-
-      Thread(V1290& tool): tool(tool) {};
-    };
-
     std::vector<caen::V1290> tdcs;
     caen::V1290::Buffer buffer;
-    std::unique_ptr<Thread> thread;
-    ToolFramework::Utilities util;
+    std::unique_ptr<ThreadLoop::handle> thread;
 
     void connect();
     void configure();
     void readout();
-
-    static void readout_thread(ToolFramework::Thread_args* arg);
-
-    void run_readout();
 };
 
 #endif

--- a/UserTools/V792/V792.cpp
+++ b/UserTools/V792/V792.cpp
@@ -150,22 +150,6 @@ void V792::readout() {
   };
 };
 
-void V792::readout_thread(Thread_args* arg) {
-  Thread* thread = static_cast<Thread*>(arg);
-  V792& tool = thread->tool;
-  try {
-    tool.readout();
-  } catch (std::exception& e) {
-    *tool.m_log << tool.ML(0) << e.what() << std::endl;
-    thread->kill = true;
-  };
-};
-
-void V792::run_readout() {
-  thread.reset(new Thread(*this));
-  util.CreateThread("V792", &readout_thread, thread.get());
-};
-
 bool V792::Initialise(std::string configfile, DataModel& data) {
   try {
     if (configfile != "") m_variables.Initialise(configfile);
@@ -192,7 +176,21 @@ bool V792::Initialise(std::string configfile, DataModel& data) {
 bool V792::Execute() {
   if (qdcs.empty()) return true;
   try {
-    run_readout();
+    thread.reset(
+        new ThreadLoop::handle(
+          m_data->vme_readout.subscribe(
+            [this]() -> bool {
+              try {
+                readout();
+                return true;
+              } catch (std::exception& e) {
+                *m_log << ML(0) << e.what() << std::endl;
+                return false;
+              }
+            }
+          )
+        )
+    );
     return true;
   } catch (std::exception& e) {
     *m_log << ML(0) << e.what() << std::endl;
@@ -203,9 +201,10 @@ bool V792::Execute() {
 bool V792::Finalise() {
   try {
     if (thread) {
-      util.KillThread(thread.get());
+      m_data->vme_readout.unsubscribe(*thread);
       delete thread.release();
     };
+
     qdcs.clear();
 
     return true;
@@ -213,4 +212,8 @@ bool V792::Finalise() {
     *m_log << ML(0) << e.what() << std::endl;
     return false;
   };
+};
+
+V792::~V792() {
+  if (thread) m_data->vme_readout.unsubscribe(*thread);
 };

--- a/UserTools/V792/V792.h
+++ b/UserTools/V792/V792.h
@@ -6,33 +6,24 @@
 #include <caen++/v792.hpp>
 
 #include "Tool.h"
-#include "Utilities.h"
+#include "ThreadLoop.h"
 
 class V792: public ToolFramework::Tool {
   public:
+    ~V792();
+
     bool Initialise(std::string configfile, DataModel&);
     bool Execute();
     bool Finalise();
 
   private:
-    struct Thread: public ToolFramework::Thread_args {
-      V792& tool;
-
-      Thread(V792& tool): tool(tool) {};
-    };
-
     std::vector<caen::V792> qdcs;
     caen::V792::Buffer buffer;
-    std::unique_ptr<Thread> thread;
-    ToolFramework::Utilities util;
+    std::unique_ptr<ThreadLoop::handle> thread;
 
     void connect();
     void configure();
     void readout();
-
-    static void readout_thread(ToolFramework::Thread_args* arg);
-
-    void run_readout();
 };
 
 #endif

--- a/UserTools/V792/V792.h
+++ b/UserTools/V792/V792.h
@@ -10,8 +10,6 @@
 
 class V792: public ToolFramework::Tool {
   public:
-    ~V792();
-
     bool Initialise(std::string configfile, DataModel&);
     bool Execute();
     bool Finalise();
@@ -19,7 +17,7 @@ class V792: public ToolFramework::Tool {
   private:
     std::vector<caen::V792> qdcs;
     caen::V792::Buffer buffer;
-    std::unique_ptr<ThreadLoop::handle> thread;
+    ThreadLoop::Thread thread;
 
     void connect();
     void configure();


### PR DESCRIPTION
USB communication has to be done by one thread only at a time, so some brokering of access to the VME bridge is required. One option would be to implement a class representing a bridge that provides access to the boards installed into the crate, but given that we will only have one crate, it feels like an overkill. Instead, I created a thread that runs a loop calling functions stored in a list. By pushing the readout functions into this list, we can ensure that they are never executed simultaneously and that all of them will be given a fair chance to execute rather than hanging on a mutex. A function can return `false` meaning that it should be erased from the list; this can also be done by the control thread by calling `ThreadLoop::Thread::terminate`. The looping thread stops if the list of functions is empty and starts again when it stops being empty. There is no protection from exceptions in the loop since it has no way to communicate errors, so it is advised to wrap functions in a try-catch block.

I'm not sure that I used the best terms to name my classes. Suggestions on renaming `ThreadLoop` and `ThreadLoop::Thread` are welcome.