### PR TITLE
Add CAEN libraries to Dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,10 +10,8 @@ ifeq ($(MAKECMDGOALS),debug)
 CXXFLAGS+= -O0 -g -lSegFault -rdynamic -DDEBUG
 endif
 
-DataModelInclude =
-#-I $(Dependencies)
-DataModelLib =
-#-L $(Dependencies)/caen++ -lcaen++ -lCAENDigitizer
+DataModelInclude = -I $(Dependencies)/caen/include
+DataModelLib = -L $(Dependencies)/caen/lib -lcaen++ -lCAENComm
 
 MyToolsInclude =
 MyToolsLib =

--- a/Setup.sh
+++ b/Setup.sh
@@ -6,6 +6,6 @@ Dependencies=`pwd`/Dependencies
 
 #source ${ToolDAQapp}/ToolDAQ/root/bin/thisroot.sh
 
-export LD_LIBRARY_PATH=`pwd`/lib:${Dependencies}/zeromq-4.0.7/lib:${Dependencies}/boost_1_66_0/install/lib:${Dependencies}/ToolFrameworkCore/lib:${Dependencies}/ToolDAQFramework/lib:${Dependencies}/caen++:$LD_LIBRARY_PATH
+export LD_LIBRARY_PATH=`pwd`/lib:${Dependencies}/zeromq-4.0.7/lib:${Dependencies}/boost_1_66_0/install/lib:${Dependencies}/ToolFrameworkCore/lib:${Dependencies}/ToolDAQFramework/lib:${Dependencies}/caen/lib:$LD_LIBRARY_PATH
 
 export SEGFAULT_SIGNALS="all"


### PR DESCRIPTION
Install CAENComm, CAENVMELib and caen++ shared object files and headers to Dependencies/caen/include and Dependencies/caen/lib.

Store archives in Dependencies/caen.

Move Dependencies/caen++ to Dependencies/caen/caen++.