### PR TITLE
V812 (CFD), V1495 (FPGA): read register settings from the database

### DIFF
--- a/UserTools/V1495/V1495.cpp
+++ b/UserTools/V1495/V1495.cpp
@@ -18,13 +18,6 @@ static unsigned long str_to_ulong(const std::string& string, int base = 10) {
   return result;
 };
 
-static uint32_t str_to_uint32(const std::string& string, int base = 10) {
-  unsigned long result = str_to_ulong(string, base);
-  if (result > std::numeric_limits<uint32_t>().max())
-    throw std::runtime_error(std::string("uint32_t overflow: ") + string);
-  return result;
-};
-
 static uint16_t str_to_uint16(const std::string& string, int base = 10) {
   unsigned long result = str_to_ulong(string, base);
   if (result > std::numeric_limits<uint16_t>().max())
@@ -32,12 +25,10 @@ static uint16_t str_to_uint16(const std::string& string, int base = 10) {
   return result;
 };
 
-static std::string slurp(const std::string& filename) {
-  std::ifstream file(filename, std::ios::ate);
-  file.exceptions(std::ios_base::badbit | std::ios_base::failbit);
-  std::string result(file.tellg(), 0);
-  file.seekg(0);
-  file.read(&result[0], result.size());
+static uint32_t str_to_uint32(const std::string& string, int base = 10) {
+  unsigned long result = str_to_ulong(string, base);
+  if (result > std::numeric_limits<uint32_t>().max())
+    throw std::runtime_error(std::string("uint32_t overflow: ") + string);
   return result;
 };
 
@@ -66,7 +57,7 @@ void V1495::configure() {
   std::string config;
   if (!m_variables.Get("config", config)) return;
   ToolFramework::Store json;
-  json.JsonParser(slurp(config));
+  json.JsonParser(config);
   for (auto& kv : json)
     board->write32(
         str_to_uint16(kv.first, 16),

--- a/UserTools/V812/V812.h
+++ b/UserTools/V812/V812.h
@@ -2,6 +2,7 @@
 #define V812_H
 
 #include <memory>
+#include <map>
 
 #include <caen++/v812.hpp>
 
@@ -15,6 +16,9 @@ class V812: public ToolFramework::Tool {
 
   private:
     std::vector<caen::V812> cfds;
+
+    // VME address -> V812
+    std::map<uint16_t, caen::V812*> pcfds;
 
     void connect();
     void configure();


### PR DESCRIPTION
For V1495 (FPGA), if the configuration JSON has an entry "config", treat it as an object with keys being register addresses and values being the values that should be written to the register addresses.

V812 (CFD) configuration is similar, except that we support a single V1495 but multiple V812s, so for V812 there is an extra level of indirection: the "config" object should map CFD VME addresses to registers settings.