### PR TITLE
QDC: take advantage of the firmware upgrade

### DIFF
--- a/UserTools/V792/V792.h
+++ b/UserTools/V792/V792.h
@@ -12,6 +12,9 @@ class V792: public Digitizer<caen::V792::Packet, QDCHit> {
   private:
     struct Board {
       caen::V792 qdc;
+      uint32_t (*readout)(Board&, caen::V792::Buffer&);
+      int      vme_handle;
+      uint32_t vme_address;
       unsigned event_map[32];
     };
 
@@ -30,6 +33,9 @@ class V792: public Digitizer<caen::V792::Packet, QDCHit> {
         unsigned                         qdc_index,
         std::vector<caen::V792::Packet>& data
     ) final;
+
+    static uint32_t readout_blt(Board&, caen::V792::Buffer&);
+    static uint32_t readout_fifoblt(Board&, caen::V792::Buffer&);
 
     void process(
         size_t                                  cycle,


### PR DESCRIPTION
Old V792 firmware does not interrupt block transfer when there is no more data, resulting in complete buffer being transferred at each readout. New firmware stops the transfer accordingly. With this patch WCTEDAQ supports both kinds of firmware and uses the more efficient readout when available.