### PR TITLE
Bring VME readout code up to date

### DIFF
--- a/DataModel/DataModel.cpp
+++ b/DataModel/DataModel.cpp
@@ -25,3 +25,50 @@ void DataModel::DeleteTTree(std::string name,TTree *tree){
 
 */
 
+void*
+DataModel::AlertSubscribe(
+    const std::string&           alert,
+    ToolFramework::AlertFunction function
+) {
+  auto list = alerts.find(alert);
+  if (list == alerts.end()) {
+    if (!services)
+      throw std::runtime_error("DataModel::AlertSubscribe: services not found");
+
+    auto broker = [this](const char* alert, const char* payload) {
+      // XXX: a function can be marked for erasure in another thread
+      auto a = alerts.find(alert);
+      if (a == alerts.end()) {
+        return;
+      };
+      auto& functions = a->second;
+      auto i = functions.begin();
+      while (i != functions.end()) {
+        auto& f = *i;
+        if (f) {
+          f(alert, payload);
+          ++i;
+        } else
+          functions.erase(i++);
+      };
+    };
+
+    if (!services->AlertSubscribe(alert, std::move(broker)))
+      throw std::runtime_error(
+          "DataModel::AlertSubscribe: could not subscribe to " + alert
+      );
+
+    list = alerts.emplace(
+        alert,
+        std::list<ToolFramework::AlertFunction> {}
+    ).first;
+  };
+
+  return &*list->second.insert(list->second.end(), std::move(function));
+};
+
+void DataModel::AlertUnsubscribe(const std::string& alert, void* handle) {
+  // mark for erasure. The entry will be erased when the alert is received.
+  *reinterpret_cast<ToolFramework::AlertFunction*>(handle)
+    = ToolFramework::AlertFunction();
+};

--- a/DataModel/DataModel.h
+++ b/DataModel/DataModel.h
@@ -4,6 +4,7 @@
 #include <map>
 #include <string>
 #include <vector>
+#include <unordered_map>
 
 #include <zmq.hpp>
 
@@ -114,8 +115,14 @@ public:
   std::mutex out_data_chunks_mtx;
 
 
+  void* AlertSubscribe(const std::string& alert, ToolFramework::AlertFunction);
+  void AlertUnsubscribe(const std::string& alert, void* handle);
   
 private:
+
+  // We need to subscribe V1290 and V792 to the beam spill alert, but ToolDAQ
+  // does not support multiple receivers on an alert.
+  std::unordered_map<std::string, std::list<ToolFramework::AlertFunction>> alerts;
   
   
   //std::map<std::string,TTree*> m_trees; 

--- a/DataModel/VMEReadout.cpp
+++ b/DataModel/VMEReadout.cpp
@@ -1,0 +1,8 @@
+#include "VMEReadout.h"
+
+namespace VMEReadout_ {
+
+constexpr const char Header<QDCHit>::signature[];
+constexpr const char Header<TDCHit>::signature[];
+
+}

--- a/DataModel/VMEReadout.h
+++ b/DataModel/VMEReadout.h
@@ -5,6 +5,11 @@
 #include <mutex>
 #include <vector>
 
+#include <zmq.hpp>
+
+#include <QDCHit.h>
+#include <TDCHit.h>
+
 template <typename Hit>
 class VMEReadout {
 public:
@@ -56,7 +61,6 @@ namespace VMEReadout_ {
 
   template <> struct Header<QDCHit> {
     static constexpr const char signature[] = "QDC";
-
   };
 
   template <> struct Header<TDCHit> {

--- a/UserTools/Digitizer/Digitizer.h
+++ b/UserTools/Digitizer/Digitizer.h
@@ -55,8 +55,7 @@ class Digitizer: public ToolFramework::Tool {
 
     // Processes the data read from board `board_index`. The data shall be
     // converted to hits and stored in the result of `get_event` which takes an
-    // event number and returns a vector of hits, one hit per channel for all
-    // channels of all boards.
+    // event number and returns a vector of hits.
     // This method if called from the worker job queues
     virtual void process(
       size_t                                  cycle,
@@ -89,7 +88,7 @@ class Digitizer: public ToolFramework::Tool {
     // for cycles[i].second: both the previous cycles and the next cycle have
     //                       been processed.
     // cycles[i].second is the largest event number seen during processing of this cycle.
-    // cycles[i].first the smallest event number across largest event number per board.
+    // cycles[i].first is the smallest event number across largest event number per board.
     std::map<size_t, std::pair<uint32_t, uint32_t>> cycles;
     std::mutex cycles_mutex;
 

--- a/UserTools/Digitizer/Digitizer.h
+++ b/UserTools/Digitizer/Digitizer.h
@@ -70,6 +70,7 @@ class Digitizer: public ToolFramework::Tool {
       size_t                           cycle;
     };
 
+    bool     standalone     = false;
     bool     acquiring_     = false;
     unsigned nboards        = 0;
     VMEReadout<Hit>* output = nullptr;
@@ -309,6 +310,7 @@ bool Digitizer<Packet, Hit>::Initialise(std::string configfile, DataModel& data)
     InitialiseConfiguration(std::move(configfile));
 
     if (!m_variables.Get("verbose", m_verbose)) m_verbose = 1;
+    m_variables.Get("standalone", standalone);
 
     init(nboards, output);
     readout_cycle = 0;
@@ -332,6 +334,12 @@ template <typename Packet, typename Hit>
 bool Digitizer<Packet, Hit>::Execute() {
   if (nboards == 0) return true;
   try {
+    if (standalone) {
+      if (acquiring_) stop_acquisition();
+      start_acquisition();
+      return true;
+    };
+
     if (m_data->run_start && !acquiring_) start_acquisition();
 
     if (m_data->change_config) {

--- a/UserTools/V1290/README.md
+++ b/UserTools/V1290/README.md
@@ -1,6 +1,6 @@
 This tool operates with CAEN V1290 time to digital converters. The tool connects
 to a number of V1290s, reads them out sequentially and stores the data in
-`DataModel::v1290_readout` for further processing. Readout is performed by
+`DataModel::tdc_readout` for further processing. Readout is performed by
 continuous polling of the cards.
 
 * `V1290::Initialise` connects to and configures the cards.

--- a/UserTools/V1290/README.md
+++ b/UserTools/V1290/README.md
@@ -7,7 +7,14 @@ continuous polling of the cards.
 * `V1290::Execute` starts the readout thread.
 * `V1290::Finalise` stops the readout thread and closes the connections.
 
-Each setting in the configuration file can be specified either as
+The following settings configure the tool in general:
+
+* `verbose`, integer: log verbosity level. The lower level, the more important
+  the log message is.
+* `standalone`, boolean: when 1, the tool does not require RunControl in the
+  toolchain and can operate independently.
+
+Each TDC setting in the configuration file can be specified either as
 ```
 setting_name value
 ```

--- a/UserTools/V1290/V1290.cpp
+++ b/UserTools/V1290/V1290.cpp
@@ -314,13 +314,13 @@ void V1290::fini() {
 };
 
 void V1290::start_acquisition() {
+  chops.clear();
   for (auto& board : boards) board.tdc.clear();
   Digitizer<caen::V1290::Packet, TDCHit>::start_acquisition();
 };
 
 void V1290::stop_acquisition() {
   Digitizer<caen::V1290::Packet, TDCHit>::stop_acquisition();
-  chops.clear();
 };
 
 void V1290::process(

--- a/UserTools/V1290/V1290.cpp
+++ b/UserTools/V1290/V1290.cpp
@@ -385,14 +385,15 @@ void V1290::process(
 
 void V1290::process(
     const std::function<Event& (uint32_t)>& get_event,
-    RawEvent& raw_event
+    RawEvent& raw
 ) {
-  Event& event = get_event(raw_event.header.event());
-  event.reserve(event.size() + raw_event.hits.size());
-  for (auto& hit : raw_event.hits)
-    event.push_back(
-        TDCHit(raw_event.header, hit, raw_event.ettt, raw_event.trailer)
-    );
+  Event& event = get_event(raw.header.event());
+
+  std::lock_guard<std::mutex> lock(*event.mutex);
+  size_t n = event.hits.size();
+  event.hits.reserve(n + raw.hits.size());
+  for (auto& hit : raw.hits)
+    event.hits.emplace_back(raw.header, hit, raw.ettt, raw.trailer);
 };
 
 void V1290::readout(

--- a/UserTools/V1290/V1290.cpp
+++ b/UserTools/V1290/V1290.cpp
@@ -295,10 +295,20 @@ void V1290::init(unsigned& nboards, VMEReadout<TDCHit>*& output) {
   configure();
   nboards = boards.size();
   output  = &m_data->tdc_readout;
+  on_spill = m_data->AlertSubscribe(
+      "SpillCount",
+      [this](const char* alert, const char* payload) {
+        for (auto& board : boards) board.tdc.reset_event();
+      }
+  );
 };
 
 void V1290::fini() {
   boards.clear();
+  if (on_spill) {
+    m_data->AlertUnsubscribe("SpillCount", on_spill);
+    on_spill = nullptr;
+  };
 };
 
 void V1290::start_acquisition() {

--- a/UserTools/V1290/V1290.cpp
+++ b/UserTools/V1290/V1290.cpp
@@ -388,6 +388,7 @@ void V1290::process(
     RawEvent& raw_event
 ) {
   Event& event = get_event(raw_event.header.event());
+  event.reserve(event.size() + raw_event.hits.size());
   for (auto& hit : raw_event.hits)
     event.push_back(
         TDCHit(raw_event.header, hit, raw_event.ettt, raw_event.trailer)

--- a/UserTools/V1290/V1290.h
+++ b/UserTools/V1290/V1290.h
@@ -27,11 +27,10 @@ class V1290: public Digitizer<caen::V1290::Packet, TDCHit> {
       void merge(RawEvent& event, bool tail);
     };
 
-    std::vector<Board> boards;
-    std::mutex tdc_errors_mutex;
+    std::vector<Board>  boards;
+    std::mutex          tdc_errors_mutex;
     caen::V1290::Buffer buffer;
-    std::map<size_t, RawEvent> chops;
-    std::mutex chops_mutex;
+    Chops<RawEvent>     chops;
 
     bool chop_event(size_t cycle, RawEvent&, bool head);
 

--- a/UserTools/V1290/V1290.h
+++ b/UserTools/V1290/V1290.h
@@ -19,11 +19,10 @@ class V1290: public Digitizer<caen::V1290::Packet, TDCHit> {
     };
 
     struct RawEvent {
-      caen::V1290::GlobalHeader           header;
-      caen::V1290::GlobalTrailer          trailer;
-      caen::V1290::ExtendedTriggerTimeTag ettt;
-      caen::V1290::TDCMeasurement         hits[32];
-      int                                 nhits;
+      caen::V1290::GlobalHeader                header;
+      caen::V1290::GlobalTrailer               trailer;
+      caen::V1290::ExtendedTriggerTimeTag      ettt;
+      std::vector<caen::V1290::TDCMeasurement> hits;
 
       void merge(RawEvent& event, bool tail);
     };

--- a/UserTools/V1290/V1290.h
+++ b/UserTools/V1290/V1290.h
@@ -31,6 +31,7 @@ class V1290: public Digitizer<caen::V1290::Packet, TDCHit> {
     std::mutex          tdc_errors_mutex;
     caen::V1290::Buffer buffer;
     Chops<RawEvent>     chops;
+    void*               on_spill;
 
     bool chop_event(size_t cycle, RawEvent&, bool head);
 

--- a/UserTools/V1495/README.md
+++ b/UserTools/V1495/README.md
@@ -38,15 +38,19 @@ The following settings describe how to connect to the V1495:
     address of the device, e.g., `90AB`. This is the number set by the rotary
     switches on the board.
 
-The only setting specific to V1495 is `config` which should provide the path to
-a JSON file containing a single object with keys being register addresses and
-values being the what is needed to be written to these address. Both keys and
-values should be string containing hexadecimal numbers (unfortunately, JSON
-format doesn't support native hexadecimal numbers). For example,
+Following settings are specific to V1495:
 
+* `registers`: a string containing a single JSON object with keys being register
+  addresses and values being numbers that will be written to these addresses.
+  Both keys and values should be strings containing hexadecimal numbers
+  (unfortunately, JSON format doesn't support native hexadecimal numbers). For
+  example,
 ```json
 {
   "0x300c": "0x01234567",
   "0x3010": "0x89abcdef"
 }
 ```
+* `counters`: a string containing a JSON array with counters registers addresses
+  in hexadecimal. Counters values will be stored in the database for each beam
+  spill.

--- a/UserTools/V1495/V1495.h
+++ b/UserTools/V1495/V1495.h
@@ -13,9 +13,11 @@ class V1495: public ToolFramework::Tool {
 
   private:
     caen::V1495* board = nullptr;
+    std::vector<uint16_t> counters;
 
     void connect();
     void configure();
+    void read_counters();
 };
 
 #endif

--- a/UserTools/V1495/V1495.h
+++ b/UserTools/V1495/V1495.h
@@ -14,10 +14,12 @@ class V1495: public ToolFramework::Tool {
   private:
     caen::V1495* board = nullptr;
     std::vector<uint16_t> counters;
+    void* on_spill;
 
     void connect();
     void configure();
     void read_counters();
+    void reset_counters();
 };
 
 #endif

--- a/UserTools/V792/README.md
+++ b/UserTools/V792/README.md
@@ -1,6 +1,6 @@
 This tool operates with CAEN V792 charge to digital converters. The tool
 connects to a number of V792s, reads them out sequentially and stores the data
-in `DataModel::v792_readout` for further processing. Readout is performed by
+in `DataModel::qdc_readout` for further processing. Readout is performed by
 continuous polling of the cards.
 
 * `V792::Initialise` connects to and configures the cards.

--- a/UserTools/V792/README.md
+++ b/UserTools/V792/README.md
@@ -7,7 +7,14 @@ continuous polling of the cards.
 * `V792::Execute` starts the readout thread.
 * `V792::Finalise` stops the readout thread and closes the connections.
 
-Each setting in the configuration file can be specified either as
+The following settings configure the tool in general:
+
+* `verbose`, integer: log verbosity level. The lower level, the more important
+  the log message is.
+* `standalone`, boolean: when 1, the tool does not require RunControl in the
+  toolchain and can operate independently.
+
+Each QDC setting in the configuration file can be specified either as
 ```
 setting_name value
 ```

--- a/UserTools/V792/V792.cpp
+++ b/UserTools/V792/V792.cpp
@@ -21,6 +21,7 @@ void V792::connect() {
   for (auto& connection : connections) {
     caen_report_connection(*m_log << ML(3), "V792", connection);
     Board board { caen::V792(connection) };
+    board.vme_address = connection.vme;
     uint16_t firmware = board.qdc.firmware_revision();
     *m_log
       << ML(3)
@@ -34,7 +35,6 @@ void V792::connect() {
         << ML(2)
         << "V792: old firmware detected, using FIFOBLT for readout"
         << std::endl;
-      board.vme_address = connection.vme;
       board.vme_handle  = board.qdc.vme_handle();
       board.readout     = readout_fifoblt;
     } else {

--- a/UserTools/V792/V792.cpp
+++ b/UserTools/V792/V792.cpp
@@ -155,10 +155,20 @@ void V792::init(unsigned& nboards, VMEReadout<QDCHit>*& output) {
   configure();
   nboards = boards.size();
   output  = &m_data->qdc_readout;
+  on_spill = m_data->AlertSubscribe(
+      "SpillCount",
+      [this](const char* alert, const char* payload) {
+        for (auto& board : boards) board.qdc.reset_event_counter();
+      }
+  );
 };
 
 void V792::fini() {
   boards.clear();
+  if (on_spill) {
+    m_data->AlertUnsubscribe("SpillCount", on_spill);
+    on_spill = nullptr;
+  };
 };
 
 void V792::start_acquisition() {

--- a/UserTools/V792/V792.cpp
+++ b/UserTools/V792/V792.cpp
@@ -304,8 +304,8 @@ void V792::process(
       throw std::runtime_error(ss.str());
     };
 
-    auto header   = packet->as<caen::V792::Header>();
-    auto ptrailer = packet + header.count() + 1;
+    auto header   = packet++->as<caen::V792::Header>();
+    auto ptrailer = packet + header.count();
     if (ptrailer < qdc_data.end()) {
       auto trailer = ptrailer->as<caen::V792::EndOfBlock>();
       process(

--- a/UserTools/V792/V792.h
+++ b/UserTools/V792/V792.h
@@ -18,8 +18,20 @@ class V792: public Digitizer<caen::V792::Packet, QDCHit> {
       unsigned event_map[32];
     };
 
+    struct RawEvent {
+      caen::V792::Header     header;
+      caen::V792::EndOfBlock trailer;
+      caen::V792::Data       hits[32];
+      unsigned               nhits;
+
+      void merge(RawEvent& event, bool tail);
+    };
+
     std::vector<Board> boards;
     caen::V792::Buffer buffer;
+    Chops<RawEvent>    chops;
+
+    void chop_event(size_t cycle, RawEvent&, bool head);
 
     void connect();
     void configure() final;
@@ -43,6 +55,18 @@ class V792: public Digitizer<caen::V792::Packet, QDCHit> {
         unsigned                                qdc_index,
         std::vector<caen::V792::Packet>         qdc_data
     ) final;
+
+    void process(
+        const std::function<Event& (uint32_t)>& get_event,
+        RawEvent&
+    );
+
+    void process(
+        const std::function<Event& (uint32_t)>& get_event,
+        caen::V792::Header,
+        caen::V792::Data*,
+        caen::V792::EndOfBlock
+    );
 };
 
 #endif

--- a/UserTools/V792/V792.h
+++ b/UserTools/V792/V792.h
@@ -15,7 +15,6 @@ class V792: public Digitizer<caen::V792::Packet, QDCHit> {
       uint32_t (*readout)(Board&, caen::V792::Buffer&);
       int      vme_handle;
       uint32_t vme_address;
-      unsigned event_map[32];
     };
 
     struct RawEvent {

--- a/UserTools/V792/V792.h
+++ b/UserTools/V792/V792.h
@@ -30,6 +30,7 @@ class V792: public Digitizer<caen::V792::Packet, QDCHit> {
     std::vector<Board> boards;
     caen::V792::Buffer buffer;
     Chops<RawEvent>    chops;
+    void*              on_spill;
 
     void chop_event(size_t cycle, RawEvent&, bool head);
 


### PR DESCRIPTION
This pull request was originally devoted to V1495 storing counters in the database, but with VME code being run on a different PC, it has been evolving independently for a while. So, I have modified this pull request to merge the VME code into the main WCTEDAQ.

The code has been tested by Arturo, however I had to modify the history to exclude commits there were helping to debug the current problem at hand.

The only place where this pull request touches non-VME specific code is [3d28ecb](https://github.com/WCTEDAQ/WCTEDAQ/pull/18/commits/3d28ecb5e1b1d2f5ebdadb1940a05f167fca6928). I needed to subscribe two tools, V792 (QDC) and V1290 (TDC), to the same alert (SpillCount), but current API did not allow it. I implemented it making a list of functions that would be called on an alert.

Since the QDC readout is still considered too slow, there might be further updates to optimize it.