### PR TITLE
Serialise readout_num and start_counter in PReadoutWindow

### DIFF
--- a/DataModel/ReadoutWindow.h
+++ b/DataModel/ReadoutWindow.h
@@ -188,6 +188,8 @@ public:
     // std::cout<<"readout window serialise"<<std::endl;
 
     bs & spill_num;
+    bs & readout_num;
+    bs & start_counter;
     
     unsigned int size = 0;
     


### PR DESCRIPTION
Currently readout_num and start_counter are not serialised so not written or read.